### PR TITLE
Add named pipe server

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Multiplayer:
 * First person and free camera spectate
 * Cheating prevention
 * Many server fixes, performance improvements, and customizable features
+* Remote administration via a named pipe server (`-pipe` argument)
 * `rf://` protocol handler for joining servers
 
 Level/mod development:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ Version 1.2.0 (Willow): Not yet released
 - Add `Suppress autoswitch` control bind (if held while picking up a weapon, autoswitch is suppressed)
 - Add `SuppressAutoswitchBindAlias` setting to `alpine_settings.ini`
 - Add `$Flag Captures While Stolen` dedicated server config option
+- Add `-pipe NAME` command line argument for remote console control via named pipe
 
 ### Bug fixes
 [@GooberRF](https://github.com/GooberRF)

--- a/game_patch/CMakeLists.txt
+++ b/game_patch/CMakeLists.txt
@@ -144,6 +144,7 @@ set(SRCS
     os/frametime.cpp
     os/timer.cpp
     os/win32_console.cpp
+    os/pipe_server.cpp
     os/os.cpp
     os/os.h
     object/object.h

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -43,6 +43,8 @@
 #include "../rf/os/os.h"
 #include "../rf/save_restore.h"
 #include "../rf/gameseq.h"
+#include "../hud/hud_internal.h"
+#include "../os/pipe_server.h"
 
 #ifdef HAS_EXPERIMENTAL
 #include "../experimental/experimental.h"
@@ -84,6 +86,9 @@ CodeInjection after_full_game_init_hook{
         multi_after_full_game_init();
         debug_init();
         load_world_hud_assets();
+
+        // Initialize named pipe server after command line parsing is complete
+        named_pipe_server_init();
 
         xlog::info("Game fully initialized");
         xlog::LoggerConfig::get().flush_appenders();

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -2257,8 +2257,8 @@ void server_add_player_weapon(rf::Player* player, int weapon_type, bool full_amm
             packet.header.size = sizeof(packet) - sizeof(packet.header);
             packet.entity_handle = entity->handle;
             packet.weapon = weapon_type;
-            packet.ammo = entity->ai.clip_ammo[weapon_type]; // could be zeroed
-            packet.clip_ammo = entity->ai.ammo[winfo.ammo_type];
+            packet.clip_ammo = entity->ai.clip_ammo[weapon_type]; // could be zeroed
+            packet.ammo = entity->ai.ammo[winfo.ammo_type];
             rf::multi_io_send_reliable(player, reinterpret_cast<uint8_t*>(&packet), sizeof(packet), 0);
         }
     }
@@ -2489,7 +2489,7 @@ void server_init()
     // Check if round is finished or if overtime should begin
     multi_check_for_round_end_hook.install();
 
-    named_pipe_server_init();
+    // Named pipe server will be initialized later in after_full_game_init_hook
 }
 
 void server_do_frame()

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -22,6 +22,7 @@
 #include "alpine_packets.h"
 #include "multi.h"
 #include "../os/console.h"
+#include "../os/pipe_server.h"
 #include "../misc/player.h"
 #include "../main/main.h"
 #include "../misc/achievements.h"
@@ -2487,6 +2488,8 @@ void server_init()
 
     // Check if round is finished or if overtime should begin
     multi_check_for_round_end_hook.install();
+
+    named_pipe_server_init();
 }
 
 void server_do_frame()

--- a/game_patch/os/os.cpp
+++ b/game_patch/os/os.cpp
@@ -106,6 +106,10 @@ static FunHook<void()> os_close_hook{
 static FunHook<void(char*, bool)> os_parse_params_hook{
     0x00523320,
     [](char *cmdline, bool skip_first) {
+        printf("[DEBUG] os_parse_params_hook called with cmdline: '%s', skip_first: %d\n", cmdline, skip_first);
+        fflush(stdout);
+        xlog::debug("os_parse_params_hook called with cmdline: '{}', skip_first: {}", cmdline, skip_first);
+        
         std::string buf;
         bool quote = false;
         while (true) {
@@ -120,6 +124,9 @@ static FunHook<void(char*, bool)> os_parse_params_hook{
                     cmd_arg.arg = static_cast<char*>(rf::operator_new(buf.size() + 1));
                     std::strcpy(cmd_arg.arg, buf.c_str());
                     cmd_arg.is_done = false;
+                    printf("[DEBUG] Parsed argument %d: '%s'\n", rf::cmdline_num_args - 1, cmd_arg.arg);
+                    fflush(stdout);
+                    xlog::debug("Parsed argument {}: '{}'", rf::cmdline_num_args - 1, cmd_arg.arg);
                 }
                 buf.clear();
                 if (!c) {
@@ -151,6 +158,10 @@ void os_apply_patch()
     os_init_window_server_hook.install();
     os_close_hook.install();
 
+    // Register command line parameters BEFORE parsing happens
+    win32_console_pre_init();
+    named_pipe_server_pre_init();
+
     // Fix quotes support in cmdline parsing
     os_parse_params_hook.install();
 
@@ -159,7 +170,4 @@ void os_apply_patch()
     void timer_apply_patch();
     frametime_apply_patch();
     timer_apply_patch();
-
-    win32_console_pre_init();
-    named_pipe_server_pre_init();
 }

--- a/game_patch/os/os.cpp
+++ b/game_patch/os/os.cpp
@@ -8,6 +8,7 @@
 #include "../rf/crt.h"
 #include "../main/main.h"
 #include "win32_console.h"
+#include "pipe_server.h"
 #include <xlog/xlog.h>
 
 const char* get_win_msg_name(UINT msg);
@@ -98,6 +99,7 @@ static FunHook<void()> os_close_hook{
     []() {
         os_close_hook.call_target();
         win32_console_close();
+        named_pipe_server_shutdown();
     },
 };
 
@@ -159,4 +161,5 @@ void os_apply_patch()
     timer_apply_patch();
 
     win32_console_pre_init();
+    named_pipe_server_pre_init();
 }

--- a/game_patch/os/pipe_server.cpp
+++ b/game_patch/os/pipe_server.cpp
@@ -1,6 +1,7 @@
 #include "pipe_server.h"
 #include "../rf/os/os.h"
 #include "../rf/os/console.h"
+#include "../rf/multi.h"
 #include <windows.h>
 #include <xlog/xlog.h>
 #include <string>

--- a/game_patch/os/pipe_server.cpp
+++ b/game_patch/os/pipe_server.cpp
@@ -21,19 +21,47 @@ static std::string g_pipe_name;
 static void pipe_thread_proc(std::string pipe_name)
 {
     std::string full_name = "\\\\.\\pipe\\" + pipe_name;
+    xlog::debug("Pipe thread started for pipe '{}'", full_name);
+    printf("[PIPE] Thread started for pipe '%s'\n", full_name.c_str());
+    fflush(stdout);
+    
     while (g_running.load()) {
+        xlog::debug("Creating named pipe '{}'", full_name);
+        printf("[PIPE] Creating named pipe '%s'\n", full_name.c_str());
+        fflush(stdout);
+        
         HANDLE pipe = CreateNamedPipeA(full_name.c_str(), PIPE_ACCESS_INBOUND,
                                        PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
-                                       1, 0, 0, 0, nullptr);
+                                       PIPE_UNLIMITED_INSTANCES, 0, 1024, 0, nullptr);
         if (pipe == INVALID_HANDLE_VALUE) {
-            xlog::error("CreateNamedPipe failed (err {})", GetLastError());
+            DWORD error = GetLastError();
+            xlog::error("CreateNamedPipe failed (err {})", error);
+            printf("[PIPE] CreateNamedPipe FAILED (err %lu)\n", error);
+            fflush(stdout);
             return;
         }
+        
+        xlog::debug("Named pipe '{}' created successfully, waiting for client connection", full_name);
+        printf("[PIPE] Named pipe '%s' created successfully, waiting for client connection\n", full_name.c_str());
+        fflush(stdout);
+        
+        // Wait for a client to connect
         BOOL connected = ConnectNamedPipe(pipe, nullptr);
-        if (!connected && GetLastError() != ERROR_PIPE_CONNECTED) {
-            CloseHandle(pipe);
-            continue;
+        if (!connected) {
+            DWORD error = GetLastError();
+            if (error != ERROR_PIPE_CONNECTED) {
+                xlog::error("ConnectNamedPipe failed (err {})", error);
+                printf("[PIPE] ConnectNamedPipe failed (err %lu)\n", error);
+                fflush(stdout);
+                CloseHandle(pipe);
+                continue;
+            }
         }
+        
+        xlog::debug("Client connected to pipe '{}'", full_name);
+        printf("[PIPE] Client connected to pipe '%s'\n", full_name.c_str());
+        fflush(stdout);
+        
         char buf[512];
         DWORD bytes_read = 0;
         while (g_running.load() && ReadFile(pipe, buf, sizeof(buf) - 1, &bytes_read, nullptr) && bytes_read) {
@@ -41,35 +69,77 @@ static void pipe_thread_proc(std::string pipe_name)
             std::string cmd{buf};
             while (!cmd.empty() && (cmd.back() == '\r' || cmd.back() == '\n'))
                 cmd.pop_back();
-            if (!cmd.empty())
+            if (!cmd.empty()) {
+                xlog::debug("Received command via pipe: '{}'", cmd);
+                printf("[PIPE] Received command: '%s'\n", cmd.c_str());
+                fflush(stdout);
                 rf::console::do_command(cmd.c_str());
+            }
         }
+        
+        xlog::debug("Client disconnected from pipe '{}'", full_name);
+        printf("[PIPE] Client disconnected from pipe '%s'\n", full_name.c_str());
+        fflush(stdout);
         DisconnectNamedPipe(pipe);
         CloseHandle(pipe);
     }
+    
+    xlog::debug("Pipe thread terminated for pipe '{}'", full_name);
+    printf("[PIPE] Thread terminated for pipe '%s'\n", full_name.c_str());
+    fflush(stdout);
 }
 
 void named_pipe_server_pre_init()
 {
+    xlog::debug("Named pipe server pre-init called");
+    printf("[PIPE] Pre-init called\n");
+    fflush(stdout);
     get_pipe_cmd_line_param();
 }
 
 void named_pipe_server_init()
 {
-    if (!get_pipe_cmd_line_param().found())
+    xlog::debug("Named pipe server init called");
+    printf("[PIPE] Init called\n");
+    fflush(stdout);
+    
+    if (!get_pipe_cmd_line_param().found()) {
+        xlog::debug("Pipe command line parameter not found - pipe server disabled");
+        printf("[PIPE] Command line parameter NOT found - pipe server disabled\n");
+        fflush(stdout);
         return;
+    }
+
+    printf("[PIPE] Command line parameter found!\n");
+    fflush(stdout);
 
     if (!rf::is_dedicated_server) {
         xlog::warn("Named pipe server started on non-dedicated server");
+        printf("[PIPE] WARNING: Started on non-dedicated server\n");
+        fflush(stdout);
     }
 
     g_pipe_name = get_pipe_cmd_line_param().get_arg();
-    if (g_pipe_name.empty())
+    xlog::debug("Pipe name from command line: '{}'", g_pipe_name);
+    printf("[PIPE] Pipe name from command line: '%s'\n", g_pipe_name.c_str());
+    fflush(stdout);
+    
+    if (g_pipe_name.empty()) {
+        xlog::debug("Pipe name is empty - pipe server disabled");
+        printf("[PIPE] Pipe name is EMPTY - pipe server disabled\n");
+        fflush(stdout);
         return;
+    }
 
+    xlog::debug("Starting pipe server thread for pipe '{}'", g_pipe_name);
+    printf("[PIPE] Starting pipe server thread for pipe '%s'\n", g_pipe_name.c_str());
+    fflush(stdout);
+    
     g_running = true;
     g_thread = std::thread(pipe_thread_proc, g_pipe_name);
     xlog::info("Named pipe server started on {}", g_pipe_name);
+    printf("[PIPE] Named pipe server started on '%s'\n", g_pipe_name.c_str());
+    fflush(stdout);
 }
 
 void named_pipe_server_shutdown()

--- a/game_patch/os/pipe_server.cpp
+++ b/game_patch/os/pipe_server.cpp
@@ -1,0 +1,87 @@
+#include "pipe_server.h"
+#include "../rf/os/os.h"
+#include "../rf/os/console.h"
+#include <windows.h>
+#include <xlog/xlog.h>
+#include <string>
+#include <thread>
+#include <atomic>
+
+static rf::CmdLineParam& get_pipe_cmd_line_param()
+{
+    static rf::CmdLineParam pipe_param{"-pipe", "", true};
+    return pipe_param;
+}
+
+static std::atomic_bool g_running{false};
+static std::thread g_thread;
+static std::string g_pipe_name;
+
+static void pipe_thread_proc(std::string pipe_name)
+{
+    std::string full_name = "\\\\.\\pipe\\" + pipe_name;
+    while (g_running.load()) {
+        HANDLE pipe = CreateNamedPipeA(full_name.c_str(), PIPE_ACCESS_INBOUND,
+                                       PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
+                                       1, 0, 0, 0, nullptr);
+        if (pipe == INVALID_HANDLE_VALUE) {
+            xlog::error("CreateNamedPipe failed (err {})", GetLastError());
+            return;
+        }
+        BOOL connected = ConnectNamedPipe(pipe, nullptr);
+        if (!connected && GetLastError() != ERROR_PIPE_CONNECTED) {
+            CloseHandle(pipe);
+            continue;
+        }
+        char buf[512];
+        DWORD bytes_read = 0;
+        while (g_running.load() && ReadFile(pipe, buf, sizeof(buf) - 1, &bytes_read, nullptr) && bytes_read) {
+            buf[bytes_read] = '\0';
+            std::string cmd{buf};
+            while (!cmd.empty() && (cmd.back() == '\r' || cmd.back() == '\n'))
+                cmd.pop_back();
+            if (!cmd.empty())
+                rf::console::do_command(cmd.c_str());
+        }
+        DisconnectNamedPipe(pipe);
+        CloseHandle(pipe);
+    }
+}
+
+void named_pipe_server_pre_init()
+{
+    get_pipe_cmd_line_param();
+}
+
+void named_pipe_server_init()
+{
+    if (!(rf::is_dedicated_server && get_pipe_cmd_line_param().found()))
+        return;
+
+    g_pipe_name = get_pipe_cmd_line_param().get_arg();
+    if (g_pipe_name.empty())
+        return;
+
+    g_running = true;
+    g_thread = std::thread(pipe_thread_proc, g_pipe_name);
+    xlog::info("Named pipe server started on {}", g_pipe_name);
+}
+
+void named_pipe_server_shutdown()
+{
+    if (!g_running)
+        return;
+    g_running = false;
+
+    if (!g_pipe_name.empty()) {
+        std::string full_name = "\\\\.\\pipe\\" + g_pipe_name;
+        HANDLE pipe = CreateFileA(full_name.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
+        if (pipe != INVALID_HANDLE_VALUE)
+            CloseHandle(pipe);
+    }
+
+    if (g_thread.joinable())
+        g_thread.join();
+    g_pipe_name.clear();
+    xlog::info("Named pipe server stopped");
+}

--- a/game_patch/os/pipe_server.cpp
+++ b/game_patch/os/pipe_server.cpp
@@ -55,8 +55,12 @@ void named_pipe_server_pre_init()
 
 void named_pipe_server_init()
 {
-    if (!(rf::is_dedicated_server && get_pipe_cmd_line_param().found()))
+    if (!get_pipe_cmd_line_param().found())
         return;
+
+    if (!rf::is_dedicated_server) {
+        xlog::warn("Named pipe server started on non-dedicated server");
+    }
 
     g_pipe_name = get_pipe_cmd_line_param().get_arg();
     if (g_pipe_name.empty())

--- a/game_patch/os/pipe_server.cpp
+++ b/game_patch/os/pipe_server.cpp
@@ -114,9 +114,10 @@ void named_pipe_server_init()
     fflush(stdout);
 
     if (!rf::is_dedicated_server) {
-        xlog::warn("Named pipe server started on non-dedicated server");
-        printf("[PIPE] WARNING: Started on non-dedicated server\n");
+        xlog::info("Named pipe server disabled - only available on dedicated servers");
+        printf("[PIPE] Pipe server disabled - only available on dedicated servers\n");
         fflush(stdout);
+        return;
     }
 
     g_pipe_name = get_pipe_cmd_line_param().get_arg();

--- a/game_patch/os/pipe_server.h
+++ b/game_patch/os/pipe_server.h
@@ -1,0 +1,5 @@
+#pragma once
+
+void named_pipe_server_pre_init();
+void named_pipe_server_init();
+void named_pipe_server_shutdown();

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(shader_compiler)
+add_subdirectory(pipe_client)

--- a/tools/pipe_client/CMakeLists.txt
+++ b/tools/pipe_client/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(pipe_client main.cpp)
+
+target_compile_features(pipe_client PUBLIC cxx_std_20)
+set_target_properties(pipe_client PROPERTIES CXX_EXTENSIONS NO)
+
+enable_warnings(pipe_client)
+setup_debug_info(pipe_client)
+
+if(MSVC)
+    target_link_libraries(pipe_client ws2_32)
+endif()

--- a/tools/pipe_client/main.cpp
+++ b/tools/pipe_client/main.cpp
@@ -17,6 +17,11 @@ int main(int argc, char* argv[])
         cmd += argv[i];
     }
 
+    if (!WaitNamedPipeA(pipe_name.c_str(), 5000)) {
+        printf("Pipe %s not available (err %lu)\n", pipe_name.c_str(), GetLastError());
+        return 1;
+    }
+
     HANDLE pipe = CreateFileA(pipe_name.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
     if (pipe == INVALID_HANDLE_VALUE) {
         printf("Failed to open pipe %s (err %lu)\n", pipe_name.c_str(), GetLastError());

--- a/tools/pipe_client/main.cpp
+++ b/tools/pipe_client/main.cpp
@@ -1,0 +1,30 @@
+#include <windows.h>
+#include <cstdio>
+#include <string>
+
+int main(int argc, char* argv[])
+{
+    if (argc < 3) {
+        printf("Usage: pipe_client <pipe_name> <command...>\n");
+        return 1;
+    }
+
+    std::string pipe_name = "\\\\.\\pipe\\" + std::string(argv[1]);
+    std::string cmd;
+    for (int i = 2; i < argc; ++i) {
+        if (i > 2)
+            cmd += ' ';
+        cmd += argv[i];
+    }
+
+    HANDLE pipe = CreateFileA(pipe_name.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
+    if (pipe == INVALID_HANDLE_VALUE) {
+        printf("Failed to open pipe %s (err %lu)\n", pipe_name.c_str(), GetLastError());
+        return 1;
+    }
+
+    DWORD written = 0;
+    WriteFile(pipe, cmd.c_str(), static_cast<DWORD>(cmd.size()), &written, nullptr);
+    CloseHandle(pipe);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement a named pipe server for dedicated servers
- enable via `-pipe` cmdline option
- expose pipe functions in server initialization and OS shutdown
- provide a simple `pipe_client` tool to send commands through the pipe

## Testing
- `cmake --build build` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6850e0670b788323b07cf9f910506c5d